### PR TITLE
Minor change in fog library ("status" method changed to "state")

### DIFF
--- a/lib/chef/knife/rackspace_server_list.rb
+++ b/lib/chef/knife/rackspace_server_list.rb
@@ -73,7 +73,7 @@ class Chef
           server_list << server.addresses["private"][0]
           server_list << server.flavor.name.split(/\s/).first
           server_list << server.image.name
-          server_list << server.status.downcase
+          server_list << server.state.downcase
         end
         puts ui.list(server_list, :columns_across, 7)
 


### PR DESCRIPTION
[KNIFE_RACKSPACE-12] correct for method change from 'status' to 'state' in fog library

`knife rackspace server list` was failing.
