### PR TITLE
fix: uninitialized constant Chef::Knife::RackspaceBase

### DIFF
--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require 'chef/knife'
+require 'chef/knife/rackspace_base'
 
 class Chef
   class Knife


### PR DESCRIPTION
This is minor change, but critical fix, since 0.5.8 release is broken!

Non of rackspace sub-commands currently works, throwing the following error:

```
uninitialized constant Chef::Knife::RackspaceBase (NameError)
```
