### PR TITLE
Fixes issue with boostrapping instances on RackSpace UK

### DIFF
--- a/lib/chef/knife/rackspace_base.rb
+++ b/lib/chef/knife/rackspace_base.rb
@@ -75,7 +75,7 @@ class Chef
         @public_dns_name ||= begin
           Resolv.getname(server.addresses["public"][0])
         rescue
-          "#{server.addresses["public"][0].gsub('.','-')}.static.cloud-ips.com"
+          "#{server.addresses["public"][0]"
         end
       end
     end


### PR DESCRIPTION
Rescue to the IP address itself as there is also RackSpace UK which has *.co.uk hostnames in the end.
