### PR TITLE
[KNIFE-47] Add more support for the London cloud (root dns entry)

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -37,6 +37,10 @@ This plugin also has support for authenticating against an alternate API Auth UR
 
     knife[:rackspace_api_auth_url] = "lon.auth.api.rackspacecloud.com"
 
+Secondly if the default root domain name of the cloud is different this can als be configured. This is useful if you are a Rackspace Cloud UK user or OpenStack early adopter.  Here is an example of configuring knife for Rackspace Cloud UK:
+
+    knife[:rackspace_api_public_dns_root_url] =  "static.cloud-ips.co.uk"
+
 Additionally the following options may be set in your `knife.rb`:
 
 * flavor

--- a/lib/chef/knife/rackspace_base.rb
+++ b/lib/chef/knife/rackspace_base.rb
@@ -52,6 +52,12 @@ class Chef
             :description => "Your rackspace API auth url",
             :default => "auth.api.rackspacecloud.com",
             :proc => Proc.new { |url| Chef::Config[:knife][:rackspace_api_auth_url] = url }
+
+          option :rackspace_api_public_dns_root_url,
+            :long => "--rackspace_api_public_dns_root_url URL",
+            :description => "Your rackspace API public DNS root url",
+            :default => "static.cloud-ips.com",
+            :proc => Proc.new { |url| Chef::Config[:knife][:rackspace_api_public_dns_root_url] = url }
         end
       end
 
@@ -75,7 +81,7 @@ class Chef
         @public_dns_name ||= begin
           Resolv.getname(server.addresses["public"][0])
         rescue
-          "#{server.addresses["public"][0].gsub('.','-')}.static.cloud-ips.com"
+          "#{server.addresses["public"][0].gsub('.','-')}.#{Chef::Config[:knife][:rackspace_api_public_dns_root_url] || config[:rackspace_api_public_dns_root_url]}"
         end
       end
     end


### PR DESCRIPTION
http://tickets.opscode.com/browse/KNIFE-47

Add configuration for the root dns entry for use with the london cloud:

knife[:rackspace_api_public_dns_root_url] =  "static.cloud-ips.co.uk"
