### PR TITLE
quick fix for flavor list command

### DIFF
--- a/lib/chef/knife/rackspace_flavor_list.rb
+++ b/lib/chef/knife/rackspace_flavor_list.rb
@@ -33,7 +33,6 @@ class Chef
           ui.color('Architecture', :bold),
           ui.color('RAM', :bold),
           ui.color('Disk', :bold),
-          ui.color('Cores', :bold)
         ]
         connection.flavors.sort_by(&:id).each do |flavor|
           flavor_list << flavor.id.to_s
@@ -41,9 +40,8 @@ class Chef
           flavor_list << "#{flavor.bits.to_s}-bit"
           flavor_list << "#{flavor.ram.to_s}"
           flavor_list << "#{flavor.disk.to_s} GB"
-          flavor_list << flavor.cores.to_s
         end
-        puts ui.list(flavor_list, :columns_across, 6)
+        puts ui.list(flavor_list, :columns_across, 5)
       end
     end
   end


### PR DESCRIPTION
fog 0.8.2 is not returning cpu count anymore :

<code>
  <Fog::Rackspace::Compute::Flavor
    id=8,
    disk=1200,
    name="30GB server",
    ram=30720

> </code>

Causing the flavor list to break.  This fix just removes the cpu column from the output.
