### PR TITLE
bump fog gem dependency to 1.2.0 because flavor list does not work

### DIFF
--- a/knife-rackspace.gemspec
+++ b/knife-rackspace.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.add_dependency "fog", "~> 0.8.2"
+  s.add_dependency "fog", ">= 1.2.0"
   s.add_dependency "chef", "~> 0.10"
   s.require_paths = ["lib"]
 


### PR DESCRIPTION
...without this commit https://github.com/fog/fog/commit/7d5a88d2e9d2139eec5b4b20276d9f460883afd9 any more
