### PR TITLE
KNIFE_RACKSPACE-33 chef-full is new default

### DIFF
--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -85,9 +85,9 @@ class Chef
       option :distro,
         :short => "-d DISTRO",
         :long => "--distro DISTRO",
-        :description => "Bootstrap a distro using a template; default is 'ubuntu10.04-gems'",
+        :description => "Bootstrap a distro using a template; default is 'chef-full'",
         :proc => Proc.new { |d| Chef::Config[:knife][:distro] = d },
-        :default => "ubuntu10.04-gems"
+        :default => "chef-full"
 
       option :template_file,
         :long => "--template-file TEMPLATE",


### PR DESCRIPTION
ubuntu10.04-gems should not be the default for knife rackspace server create
