### PR TITLE
[KNIFE-273] honor command line over knife.rb settings

### DIFF
--- a/lib/chef/knife/rackspace_base.rb
+++ b/lib/chef/knife/rackspace_base.rb
@@ -68,7 +68,9 @@ class Chef
 
       def locate_config_value(key)
         key = key.to_sym
-        Chef::Config[:knife][key] || config[key]
+        config[key]
+        # We used to look here first, but that doesn't let us over-ride on the command line what is in the file
+        # Chef::Config[:knife][key]
       end
 
       def public_dns_name(server)


### PR DESCRIPTION
http://tickets.opscode.com/browse/KNIFE-273

Prior to this, the anything from knife.rb (ie flavor, image, etc) overrode options on the command line.
This seems to work for most settings I looked through and use regularly.
