### PR TITLE
Bootstrap faling for rackspace sometimes due to DNS issues from rackspace  

### DIFF
--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -197,7 +197,7 @@ class Chef
 
       def bootstrap_for_node(server)
         bootstrap = Chef::Knife::Bootstrap.new
-        bootstrap.name_args = [public_dns_name(server)]
+        bootstrap.name_args = server.addresses["public"][0]
         bootstrap.config[:run_list] = config[:run_list]
         bootstrap.config[:first_boot_attributes] = config[:first_boot_attributes]
         bootstrap.config[:ssh_user] = config[:ssh_user] || "root"


### PR DESCRIPTION
...ge " ERROR: Network Error: getaddrinfo: nodename nor servname provided, or not known" Changed the code to use IP address for bootstrapping
