### PR TITLE
OC-4235: 'delay-loading' changes to reduce load-time

### DIFF
--- a/lib/chef/knife/rackspace_base.rb
+++ b/lib/chef/knife/rackspace_base.rb
@@ -16,8 +16,6 @@
 # limitations under the License.
 #
 
-require 'chef/knife'
-
 class Chef
   class Knife
     module RackspaceBase
@@ -32,7 +30,9 @@ class Chef
             require 'fog'
             require 'net/ssh/multi'
             require 'readline'
+            require 'chef/knife'
             require 'chef/json_compat'
+            Chef::Knife.load_deps
           end
 
           option :rackspace_api_key,
@@ -87,5 +87,3 @@ class Chef
     end
   end
 end
-
-

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -25,9 +25,6 @@ class Chef
       include Knife::RackspaceBase
 
       deps do
-        require 'fog'
-        require 'readline'
-        require 'chef/json_compat'
         require 'chef/knife/bootstrap'
         Chef::Knife::Bootstrap.load_deps
       end


### PR DESCRIPTION
Here are findings, load-time differences before & after code changes.
# knife-core(no-plugins)

```
    real    0m0.744s
    user    0m0.688s
    sys     0m0.052s
```
# knife(with knife-azure, knife-google, knife-hp, knife-ec2, knife-windows,knife-terremark, knife-rackspace)

```
# before changes, 
    real    0m6.635s
    user    0m3.736s
    sys     0m0.376s

# After changes, 
    real    0m4.805s
    user    0m3.452s
    sys     0m0.272s
```

Environment:
1. Chef Version: 10.14.2
2. Ruby Version: 1.9.3p194
3. Gem Version: 1.8.24
