### PR TITLE
KNIFE-181

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v0.6.4
+* KNIFE-181 correct mixed use of 'rackspace_auth_url' and 'rackspace_api_auth_url'. Only 'rackspace_auth_url' is correct.
 * KNIFE-182 default to Rackspace Open Cloud (v2)
 
 ## v0.6.2

--- a/README.rdoc
+++ b/README.rdoc
@@ -39,7 +39,7 @@ To select for the previous Rackspace API (aka 'v1'), you can use the <tt>--racks
 
 This plugin also has support for authenticating against an alternate API Auth URL. This is useful if you are a Rackspace Cloud UK user, here is an example of configuring your <tt>knife.rb</tt>:
 
-    knife[:rackspace_api_auth_url] = "lon.auth.api.rackspacecloud.com"
+    knife[:rackspace_auth_url] = "lon.auth.api.rackspacecloud.com"
 
 This plugin also has support for specifying which region to create servers into:
 

--- a/lib/chef/knife/rackspace_base.rb
+++ b/lib/chef/knife/rackspace_base.rb
@@ -53,11 +53,11 @@ class Chef
             :default => "v2",
             :proc => Proc.new { |version| Chef::Config[:knife][:rackspace_version] = version }
 
-          option :rackspace_api_auth_url,
-            :long => "--rackspace-api-auth-url URL",
+          option :rackspace_auth_url,
+            :long => "--rackspace-auth-url URL",
             :description => "Your rackspace API auth url",
             :default => "auth.api.rackspacecloud.com",
-            :proc => Proc.new { |url| Chef::Config[:knife][:rackspace_api_auth_url] = url }
+            :proc => Proc.new { |url| Chef::Config[:knife][:rackspace_auth_url] = url }
 
           option :rackspace_endpoint,
             :long => "--rackspace-endpoint URL",
@@ -74,7 +74,7 @@ class Chef
         Chef::Log.debug("rackspace_username #{Chef::Config[:knife][:rackspace_username]}")
         Chef::Log.debug("rackspace_api_username #{Chef::Config[:knife][:rackspace_api_username]}")
         Chef::Log.debug("rackspace_auth_url #{Chef::Config[:knife][:rackspace_auth_url]} (config)")
-        Chef::Log.debug("rackspace_auth_url #{config[:rackspace_api_auth_url]} (cli)")
+        Chef::Log.debug("rackspace_auth_url #{config[:rackspace_auth_url]} (cli)")
         Chef::Log.debug("rackspace_endpoint #{Chef::Config[:knife][:rackspace_endpoint]} (config)")
         Chef::Log.debug("rackspace_endpoint #{config[:rackspace_endpoint]} (cli)")
         if (Chef::Config[:knife][:rackspace_version] == 'v1') || (config[:rackspace_version] == 'v1')
@@ -85,7 +85,7 @@ class Chef
               :version => 'v1',
               :rackspace_api_key => Chef::Config[:knife][:rackspace_api_key],
               :rackspace_username => (Chef::Config[:knife][:rackspace_username] || Chef::Config[:knife][:rackspace_api_username]),
-              :rackspace_auth_url => Chef::Config[:knife][:rackspace_api_auth_url] || config[:rackspace_api_auth_url]
+              :rackspace_auth_url => Chef::Config[:knife][:rackspace_auth_url] || config[:rackspace_auth_url]
             )
           end
         else
@@ -96,7 +96,7 @@ class Chef
               :version => 'v2',
               :rackspace_api_key => Chef::Config[:knife][:rackspace_api_key],
               :rackspace_username => (Chef::Config[:knife][:rackspace_username] || Chef::Config[:knife][:rackspace_api_username]),
-              :rackspace_auth_url => Chef::Config[:knife][:rackspace_api_auth_url] || config[:rackspace_api_auth_url],
+              :rackspace_auth_url => Chef::Config[:knife][:rackspace_auth_url] || config[:rackspace_auth_url],
               :rackspace_endpoint => Chef::Config[:knife][:rackspace_endpoint] || config[:rackspace_endpoint]
             )
           end


### PR DESCRIPTION
Builds off the work in the KNIFE-182 pull request. Essentially we were using a mix of rackspace_auth_url and rackspace_api_auth_url, which isn't a thing to Fog. I updated everything to match Fog's rackspace_auth_url.
