### PR TITLE
Replace deprecated option rackspace_endpoint by rackspace_compute_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.7.1
+* Use rackspace_compute_url instead of deprecated rackspace_endpoint
+
 ## v0.7.0
 * KNIFE_RACKSPACE-32 Ensure hint file is created to improve Ohai detection.
 * KNIFE-181 correct mixed use of 'rackspace_auth_url' and 'rackspace_api_auth_url'. Only 'rackspace_auth_url' is correct.

--- a/README.rdoc
+++ b/README.rdoc
@@ -43,7 +43,7 @@ This plugin also has support for authenticating against an alternate API Auth UR
 
 This plugin also has support for specifying which region to create servers into:
 
-    knife[:rackspace_endpoint] = "https://dfw.servers.api.rackspacecloud.com/v2"
+    knife[:rackspace_compute_url] = "https://dfw.servers.api.rackspacecloud.com/v2"
 
 valid options include:
       DFW_ENDPOINT = 'https://dfw.servers.api.rackspacecloud.com/v2'

--- a/lib/chef/knife/rackspace_base.rb
+++ b/lib/chef/knife/rackspace_base.rb
@@ -59,11 +59,11 @@ class Chef
             :default => "auth.api.rackspacecloud.com",
             :proc => Proc.new { |url| Chef::Config[:knife][:rackspace_auth_url] = url }
 
-          option :rackspace_endpoint,
-            :long => "--rackspace-endpoint URL",
+          option :rackspace_compute_url,
+            :long => "--rackspace-compute-url URL",
             :description => "Your rackspace API endpoint",
             :default => "https://dfw.servers.api.rackspacecloud.com/v2",
-            :proc => Proc.new { |url| Chef::Config[:knife][:rackspace_endpoint] = url }
+            :proc => Proc.new { |url| Chef::Config[:knife][:rackspace_compute_url] = url }
 
           option :file,
             :long => '--file DESTINATION-PATH=SOURCE-PATH',
@@ -83,8 +83,8 @@ class Chef
         Chef::Log.debug("rackspace_api_username #{Chef::Config[:knife][:rackspace_api_username]}")
         Chef::Log.debug("rackspace_auth_url #{Chef::Config[:knife][:rackspace_auth_url]} (config)")
         Chef::Log.debug("rackspace_auth_url #{config[:rackspace_auth_url]} (cli)")
-        Chef::Log.debug("rackspace_endpoint #{Chef::Config[:knife][:rackspace_endpoint]} (config)")
-        Chef::Log.debug("rackspace_endpoint #{config[:rackspace_endpoint]} (cli)")
+        Chef::Log.debug("rackspace_compute_url #{Chef::Config[:knife][:rackspace_compute_url]} (config)")
+        Chef::Log.debug("rackspace_compute_url #{config[:rackspace_compute_url]} (cli)")
         if (Chef::Config[:knife][:rackspace_version] == 'v1') || (config[:rackspace_version] == 'v1')
           Chef::Log.debug("rackspace v1")
           @connection ||= begin
@@ -97,7 +97,7 @@ class Chef
           @connection ||= begin
             connection = Fog::Compute.new(connection_params({
               :version => 'v2',
-              :rackspace_endpoint => Chef::Config[:knife][:rackspace_endpoint] || config[:rackspace_endpoint]
+              :rackspace_compute_url => Chef::Config[:knife][:rackspace_compute_url] || config[:rackspace_compute_url]
             }))
           end
         end

--- a/lib/knife-rackspace/version.rb
+++ b/lib/knife-rackspace/version.rb
@@ -1,6 +1,6 @@
 module Knife
   module Rackspace
-    VERSION = "0.7.0"
+    VERSION = "0.7.1"
     MAJOR, MINOR, TINY = VERSION.split('.')
   end
 end


### PR DESCRIPTION
I didn't see how to file an issue so here is a pull request which will serve at least as explanation of the issue. Be aware that it doesn't maintain backward compatibility.
