### PR TITLE
KNIFE-314 fixed first gen server provisioning

### DIFF
--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -289,9 +289,12 @@ class Chef
           :metadata => Chef::Config[:knife][:rackspace_metadata],
           :personality => files
         )
-        server.save(
-          :networks => networks
-        )
+
+        if version_one?
+          server.save
+        else
+          server.save(:networks => networks)
+        end
 
         msg_pair("Instance ID", server.id)
         msg_pair("Host ID", server.host_id)


### PR DESCRIPTION
Fixed issue causing first gen server provisioning to crash. http://tickets.opscode.com/browse/KNIFE-314
