### PR TITLE
Fix ip_addr -> ip_address in server delete

### DIFF
--- a/lib/chef/knife/rackspace_server_delete.rb
+++ b/lib/chef/knife/rackspace_server_delete.rb
@@ -67,8 +67,8 @@ class Chef
             msg_pair("Name", server.name)
             msg_pair("Flavor", server.flavor.name)
             msg_pair("Image", server.image.name)
-            msg_pair("Public IP Address", ip_addr(server, 'public'))
-            msg_pair("Private IP Address", ip_addr(server, 'private'))
+            msg_pair("Public IP Address", ip_address(server, 'public'))
+            msg_pair("Private IP Address", ip_address(server, 'private'))
 
             puts "\n"
             confirm("Do you really want to delete this server")


### PR DESCRIPTION
When I renamed this method for KNIFE-366 I neglected to check other files that I hadn't touched. It turns out that `rackspace server delete` uses it to display IP addresses as well. It'll fail with the rather cryptic "could not locate server" since `NoMethodError` is rescued.

Not sure if this needs another ticket or if you can just pull it in as part of KNIFE-366.
