### PR TITLE
Fixing issue with bootstrapping Windows server

### DIFF
--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -111,8 +111,7 @@ class Chef
         :short => "-d DISTRO",
         :long => "--distro DISTRO",
         :description => "Bootstrap a distro using a template; default is 'chef-full'",
-        :proc => Proc.new { |d| Chef::Config[:knife][:distro] = d },
-        :default => "chef-full"
+        :proc => Proc.new { |d| Chef::Config[:knife][:distro] = d }
 
       option :template_file,
         :long => "--template-file TEMPLATE",
@@ -432,6 +431,7 @@ class Chef
         bootstrap.config[:host_key_verify] = config[:host_key_verify]
         # bootstrap will run as root...sudo (by default) also messes up Ohai on CentOS boxes
         bootstrap.config[:use_sudo] = true unless config[:ssh_user] == 'root'
+        bootstrap.config[:distro] = locate_config_value(:distro)  || 'chef-full'
         bootstrap_common_params(bootstrap, server)
       end
 
@@ -445,7 +445,6 @@ class Chef
         end
         bootstrap.config[:prerelease] = config[:prerelease]
         bootstrap.config[:bootstrap_version] = locate_config_value(:bootstrap_version)
-        bootstrap.config[:distro] = locate_config_value(:distro)
         bootstrap.config[:template_file] = locate_config_value(:template_file)
         bootstrap.config[:first_boot_attributes] = config[:first_boot_attributes]
         bootstrap.config[:bootstrap_proxy] = locate_config_value(:bootstrap_proxy)
@@ -463,6 +462,7 @@ class Chef
         bootstrap.config[:winrm_password] = locate_config_value(:winrm_password) || server.password
         bootstrap.config[:winrm_transport] = locate_config_value(:winrm_transport)
         bootstrap.config[:winrm_port] = locate_config_value(:winrm_port)
+        bootstrap.config[:distro] = locate_config_value(:distro)  || 'windows-chef-client-msi'
         bootstrap_common_params(bootstrap, server)
       end
 


### PR DESCRIPTION
Hello,

I found a problem with bootstrapping Windows servers where knife would just throw an exception after waiting for winrm to become available. The command to create the server was as below:

`knife rackspace server create --image 332bdd7a-5eed-47da-bbde-d62c8cfdbc23 --flavor 3 --file C:\cloud-automation\bootstrap.cmd=bootstrap.cmd --bootstrap-protocol winrm -N knifeRAXwin`

The actual exception was thrown in [windows_bootstrap_context.rb](https://github.com/opscode/knife-windows/blob/2bbc98ea2593ea595ac0cca59f48231c96d0c081/lib/chef/knife/core/windows_bootstrap_context.rb#L172) on line 172 and I managed to narrow it down to knife trying to use the wrong template file to bootstrap the node (using the Linux one rather than the Windows one). The exception was (and this was already running with `-VV`):

```
Waiting for winrm...Bootstrapping Chef on 162.13.145.188
ERROR: knife encountered an unexpected error
This may be a bug in the 'rackspace server create' knife command or plugin
Please collect the output of this command with the `-VV` option before filing a bug report.
Exception: NoMethodError: undefined method `gsub' for nil:NilClass
```

 As the default behavior of `knife bootstrap windows winrm ...` is to work without specifying a distro explicitly I have gone ahead and and removed the default value for the `--distro` option and set this in the respective methods [bootstrap_for_node](https://github.com/opscode/knife-rackspace/blob/master/lib/chef/knife/rackspace_server_create.rb#L425) and [bootstrap_for_windows_node](https://github.com/opscode/knife-rackspace/blob/master/lib/chef/knife/rackspace_server_create.rb#L459). I have tested the the modified gem locally and was able to spin up and bootstrap Windows and Linux server.

Thanks
Nico
