### PR TITLE
Change include? to has_key? to fix ERROR: TypeError

### DIFF
--- a/lib/chef/knife/rackspace_base.rb
+++ b/lib/chef/knife/rackspace_base.rb
@@ -127,8 +127,8 @@ class Chef
           hash[:connection_options] = {:proxy => Chef::Config[:https_proxy] || Chef::Config[:http_proxy] }
         end
         Chef::Log.debug("using proxy #{hash[:connection_options][:proxy] || "<none>"} (config)")
-        Chef::Log.debug("ssl_verify_peer #{Chef::Config[:knife].include?(:ssl_verify_peer) ? Chef::Config[:knife][:ssl_verify_peer] : "<not specified>"} (config)")
-        hash[:connection_options][:ssl_verify_peer] = Chef::Config[:knife][:ssl_verify_peer] if Chef::Config[:knife].include?(:ssl_verify_peer)
+        Chef::Log.debug("ssl_verify_peer #{Chef::Config[:knife].has_key?(:ssl_verify_peer) ? Chef::Config[:knife][:ssl_verify_peer] : "<not specified>"} (config)")
+        hash[:connection_options][:ssl_verify_peer] = Chef::Config[:knife][:ssl_verify_peer] if Chef::Config[:knife].has_key?(:ssl_verify_peer)
 
         hash
       end


### PR DESCRIPTION
Just saw this in IRC after experiencing it myself on a fresh omnibus
install of chef with knife-rackspace:

```
<ziftytodd> Just installed Chef on my workstation. Trying to use knife
rackspace server list/create/etc, but all variations result in ERROR:
TypeError: wrong argument type Symbol (expected Module). Any ideas on
what might be wrong?
```

The process I used to do the install:
- standard omnibus install from opscode install instructions for ubuntu
- /opt/chef/embedded/bin/gem install knife-rackspace (root via sudo -i)

This small fix I did live on my installation solved my issues but I
don't know if it is a workaround or a solution.  If anyone can let me
know if this is a good fix or also works for them that would be awesome.
