### PR TITLE
increased fog version to fog ~> 1.16

### DIFF
--- a/knife-rackspace.gemspec
+++ b/knife-rackspace.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.add_dependency "knife-windows"
-  s.add_dependency "fog", "~> 1.12"
+  s.add_dependency "fog", '~> 1.16'
   s.add_dependency "chef", ">= 0.10.10"
   s.require_paths = ["lib"]
 


### PR DESCRIPTION
This PR increases the fog dependency to ~> 1.16 in keeping up with knife-ec2
