### PR TITLE
[KNIFE-440] fix two minor typos in the ui.error message

### DIFF
--- a/lib/chef/knife/rackspace_base.rb
+++ b/lib/chef/knife/rackspace_base.rb
@@ -112,7 +112,7 @@ class Chef
 
       def connection_params(options={})
         unless locate_config_value(:rackspace_region)
-          ui.error "Please specify region via the command line using the --rackpace-region switch oradd a knife[:rackspace_region] = REGION to your knife file."
+          ui.error "Please specify region via the command line using the --rackspace-region switch or add a knife[:rackspace_region] = REGION to your knife file."
           exit 1
         end
 


### PR DESCRIPTION
Two minor typos in the error message.
