### PR TITLE
bugfix:  using subdomain of xip.io buggy

### DIFF
--- a/lib/chef/knife/rackspace_base.rb
+++ b/lib/chef/knife/rackspace_base.rb
@@ -175,7 +175,7 @@ class Chef
           @public_dns_name ||= begin
             Resolv.getname(public_ip_address)
           rescue
-            "#{public_ip_address}.rs-cloud.xip.io"
+            "#{public_ip_address}.xip.io"
           end
         end
       end


### PR DESCRIPTION
rs-cloud.xip.io initially behaved as expected,  but doesn't seem to anymore.

we should just use `#{public_ip_address}.xip.io`

https://tickets.opscode.com/browse/KNIFE-452
