### PR TITLE
KNIFE-460 Remove extraneous flavor reloads

### DIFF
--- a/lib/chef/knife/rackspace_flavor_list.rb
+++ b/lib/chef/knife/rackspace_flavor_list.rb
@@ -45,8 +45,6 @@ class Chef
           ]
         end
         connection.flavors.sort_by(&:id).each do |flavor|
-
-          flavor = connection.flavors.get(flavor.id)
           bits = flavor.respond_to?(:bits) ? "#{flavor.bits.to_s}-bit" : ""
 
           flavor_list << flavor.id.to_s


### PR DESCRIPTION
Fog now retrieves the full flavor details when you call `connection.flavors` make the subsequent `flavor = connection.flavors.get(flavor.id)` unnecessary.
