### PR TITLE
[KNIFE-498] knife rackspace uses direct TCP connection on port 22 to verify SSHD

### DIFF
--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -245,7 +245,7 @@ class Chef
       end
 
       def tcp_test_ssh(hostname)
-        sleep config[:ssh_wait_timeout]
+        sleep config[:ssh_wait_timeout].to_i
 
         # if this feature is disabled, just return true to skip it
         return true if not config[:tcp_test_ssh]


### PR DESCRIPTION
This adds two options: to disable the TCP check on port 22, and to wait/sleep before doing the TCP check. I decided to call the option ssh_wait_timeout as it needs to sleep _before_ the tcp check.

If you're using a ProxyCommand or any other kind of ssh gateway, the SSHD wait no longer works using the method at:

https://github.com/opscode/knife-rackspace/blob/master/lib/chef/knife/rackspace_server_create.rb#L237-239

Since knife bootstrap can use ssh gateways, the TCP check doesn't really model what would happen with knife bootstrap's communication to the server.
