### PR TITLE
Replaces deprecated :keypair for :key_name.

### DIFF
--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -348,7 +348,7 @@ class Chef
           :user_data => user_data,
           :config_drive => locate_config_value(:rackspace_config_drive) || false,
           :personality => files,
-          :keypair => Chef::Config[:knife][:rackspace_ssh_keypair]
+          :key_name => Chef::Config[:knife][:rackspace_ssh_keypair]
         )
 
         if version_one?


### PR DESCRIPTION
When using a ssh keypair with `knife server create` it will output the
following warning:

> [fog][DEPRECATION] :keypair has been depreciated. Please use :key_name
> instead.

This commit fixes that warning.
